### PR TITLE
Add image mirror utility and workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,35 @@
+
+# Copyright (c) 2022 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Mirror Container Images
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: 0 5 * * *
+    
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Update packages
+      run: sudo apt-get -y update
+    - name: Install Skopeo
+      run: sudo apt-get -y install skopeo
+    - name: Login to Quay
+      uses: docker/login-action@v1 
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_TOKEN }}
+    - name: Mirror Container Images
+      run: ./image-mirror.sh quay.io/devfile

--- a/image-mirror.sh
+++ b/image-mirror.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DEST_ORG=$1
+
+cat mirror_list.txt
+
+while read -r image_repo;
+do
+   echo "Mirroring $image_repo to $DEST_ORG"
+   skopeo sync --src docker --dest docker $image_repo $DEST_ORG --override-os linux
+done < "mirror_list.txt"

--- a/mirror_list.txt
+++ b/mirror_list.txt
@@ -1,0 +1,4 @@
+golang:latest
+node:lts-slim
+node:lts
+composer:2.1.11


### PR DESCRIPTION
Fixes https://github.com/devfile/api/issues/848

This PR adds the following:

- A simple shell script that uses Skopeo to mirror images in a text file (mirror_list.txt) to a given destination registry (e.g. quay.io)
- A GitHub workflow to run after merges to main, and also at midnight each night.
   - The referenced secrets have already been added to this repository's configuration