### PR TITLE
[Devtools week] Update composer mirror image tag

### DIFF
--- a/mirror_list.txt
+++ b/mirror_list.txt
@@ -1,1 +1,1 @@
-composer:2.4
+composer:2.5.8


### PR DESCRIPTION
# Description

Updates the composer reference to use `2.5.8` for future mirror runs to update `quay.io/devfile/composer`. This is needed for updating the laravell stack in the community devfile registry: devfile/api#1132